### PR TITLE
go.mod: rename package to batch-change-utils

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sourcegraph/campaignutils
+module github.com/sourcegraph/batch-change-utils
 
 go 1.15
 

--- a/json/validate.go
+++ b/json/validate.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 
-	"github.com/sourcegraph/campaignutils/jsonschema"
+	"github.com/sourcegraph/batch-change-utils/jsonschema"
 )
 
 // UnmarshalValidate validates the JSON input against the provided JSON schema.

--- a/json/validate_test.go
+++ b/json/validate_test.go
@@ -15,7 +15,7 @@ func TestUnmarshalValidate(t *testing.T) {
 
 	schema := `{
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "$id": "https://github.com/sourcegraph/campaignutils/schema/test.schema.json",
+        "$id": "https://github.com/sourcegraph/batch-change-utils/schema/test.schema.json",
         "type": "object",
         "properties": {
             "a": { "type": "string" },

--- a/yaml/validate.go
+++ b/yaml/validate.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 
-	"github.com/sourcegraph/campaignutils/jsonschema"
+	"github.com/sourcegraph/batch-change-utils/jsonschema"
 
 	yamlv3 "gopkg.in/yaml.v3"
 )

--- a/yaml/validate_test.go
+++ b/yaml/validate_test.go
@@ -15,7 +15,7 @@ func TestUnmarshalValidate(t *testing.T) {
 
 	schema := `{
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "$id": "https://github.com/sourcegraph/campaignutils/schema/test.schema.json",
+        "$id": "https://github.com/sourcegraph/batch-change-utils/schema/test.schema.json",
         "type": "object",
         "properties": {
             "a": { "type": "string" },


### PR DESCRIPTION
This should be safe for downstream consumers, since their go.sum files are pinned to specific revisions.