### PR TITLE
Extract `output` package from `src-cli` and expose it here

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,12 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-cmp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.0
+	github.com/mattn/go-isatty v0.0.12
+	github.com/mattn/go-runewidth v0.0.9
+	github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1
 	github.com/pkg/errors v0.9.1
 	github.com/xeipuuv/gojsonschema v1.2.0
+	golang.org/x/sys v0.0.0-20200116001909-b77594299b42
 	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,12 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1 h1:lh3PyZvY+B9nFliSGTn5uFuqQQJGuNrD0MLCokv09ag=
+github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -23,6 +29,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHo
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/output/_examples/main.go
+++ b/output/_examples/main.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"flag"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sourcegraph/src-cli/internal/output"
+)
+
+var (
+	duration time.Duration
+	verbose  bool
+	withBars bool
+)
+
+func init() {
+	flag.DurationVar(&duration, "progress", 5*time.Second, "time to take in the progress bar and pending samples")
+	flag.BoolVar(&verbose, "verbose", false, "enable verbose mode")
+	flag.BoolVar(&withBars, "with-bars", false, "show status bars on top of progress bar")
+}
+
+func main() {
+	flag.Parse()
+
+	out := output.NewOutput(flag.CommandLine.Output(), output.OutputOpts{
+		Verbose: verbose,
+	})
+
+	if withBars {
+		demoProgressWithBars(out, duration)
+	} else {
+		demo(out, duration)
+	}
+}
+
+func demo(out *output.Output, duration time.Duration) {
+	var wg sync.WaitGroup
+	progress := out.Progress([]output.ProgressBar{
+		{Label: "A", Max: 1.0},
+		{Label: "BB", Max: 1.0, Value: 0.5},
+		{Label: strings.Repeat("X", 200), Max: 1.0},
+	}, nil)
+
+	wg.Add(1)
+	go func() {
+		ticker := time.NewTicker(duration / 20)
+		defer ticker.Stop()
+		defer wg.Done()
+
+		i := 0
+		for range ticker.C {
+			i += 1
+			if i > 20 {
+				return
+			}
+
+			progress.Verbosef("%slog line %d", output.StyleWarning, i)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		defer wg.Done()
+
+		start := time.Now()
+		until := start.Add(duration)
+		for range ticker.C {
+			now := time.Now()
+			if now.After(until) {
+				return
+			}
+
+			progress.SetValue(0, float64(now.Sub(start))/float64(duration))
+			progress.SetValue(1, 0.5+float64(now.Sub(start))/float64(duration)/2)
+			progress.SetValue(2, 2*float64(now.Sub(start))/float64(duration))
+		}
+	}()
+
+	wg.Wait()
+	progress.Complete()
+
+	func() {
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+
+		pending := out.Pending(output.Linef("", output.StylePending, "Starting pending ticker"))
+		defer pending.Complete(output.Line(output.EmojiSuccess, output.StyleSuccess, "Ticker done!"))
+
+		until := time.Now().Add(duration)
+		for range ticker.C {
+			now := time.Now()
+			if now.After(until) {
+				return
+			}
+
+			pending.Updatef("Waiting for another %s", time.Until(until))
+		}
+	}()
+
+	out.Write("")
+	block := out.Block(output.Line(output.EmojiSuccess, output.StyleSuccess, "Done!"))
+	block.Write("Here is some additional information.\nIt even line wraps.")
+	block.Close()
+}
+
+func demoProgressWithBars(out *output.Output, duration time.Duration) {
+	var wg sync.WaitGroup
+	progress := out.ProgressWithStatusBars([]output.ProgressBar{
+		{Label: "Running steps", Max: 1.0},
+	}, []*output.StatusBar{
+		output.NewStatusBarWithLabel("github.com/sourcegraph/src-cli"),
+		output.NewStatusBarWithLabel("github.com/sourcegraph/sourcegraph"),
+	}, nil)
+
+	wg.Add(1)
+	go func() {
+		ticker := time.NewTicker(duration / 10)
+		defer ticker.Stop()
+		defer wg.Done()
+
+		i := 0
+		for range ticker.C {
+			i += 1
+			if i > 10 {
+				return
+			}
+
+			progress.Verbosef("%slog line %d", output.StyleWarning, i)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		defer wg.Done()
+
+		start := time.Now()
+		until := start.Add(duration)
+		for range ticker.C {
+			now := time.Now()
+			if now.After(until) {
+				return
+			}
+
+			elapsed := time.Since(start)
+
+			if elapsed < 5*time.Second {
+				if elapsed < 1*time.Second {
+					progress.StatusBarUpdatef(0, "Downloading archive...")
+					progress.StatusBarUpdatef(1, "Downloading archive...")
+
+				} else if elapsed > 1*time.Second && elapsed < 2*time.Second {
+					progress.StatusBarUpdatef(0, `comby -in-place 'fmt.Sprintf("%%d", :[v])' 'strconv.Itoa(:[v])' main.go`)
+					progress.StatusBarUpdatef(1, `comby -in-place 'fmt.Sprintf("%%d", :[v])' 'strconv.Itoa(:[v])' pkg/main.go pkg/utils.go`)
+
+				} else if elapsed > 2*time.Second && elapsed < 4*time.Second {
+					progress.StatusBarUpdatef(0, `goimports -w main.go`)
+					if elapsed > (2*time.Second + 500*time.Millisecond) {
+						progress.StatusBarUpdatef(1, `goimports -w pkg/main.go pkg/utils.go`)
+					}
+
+				} else if elapsed > 4*time.Second && elapsed < 5*time.Second {
+					progress.StatusBarCompletef(1, `Done!`)
+					if elapsed > (4*time.Second + 500*time.Millisecond) {
+						progress.StatusBarCompletef(0, `Done!`)
+					}
+				}
+			}
+
+			if elapsed > 5*time.Second && elapsed < 6*time.Second {
+				progress.StatusBarResetf(0, "github.com/sourcegraph/code-intel", `Downloading archive...`)
+				if elapsed > (5*time.Second + 200*time.Millisecond) {
+					progress.StatusBarResetf(1, "github.com/sourcegraph/srcx86", `Downloading archive...`)
+				}
+			} else if elapsed > 6*time.Second && elapsed < 7*time.Second {
+				progress.StatusBarUpdatef(1, `comby -in-place 'fmt.Sprintf("%%d", :[v])' 'strconv.Itoa(:[v])' main.go (%s)`)
+				if elapsed > (6*time.Second + 100*time.Millisecond) {
+					progress.StatusBarUpdatef(0, `comby -in-place 'fmt.Sprintf("%%d", :[v])' 'strconv.Itoa(:[v])' main.go`)
+				}
+			} else if elapsed > 7*time.Second && elapsed < 8*time.Second {
+				progress.StatusBarCompletef(0, "Done!")
+				if elapsed > (7*time.Second + 320*time.Millisecond) {
+					progress.StatusBarCompletef(1, "Done!")
+				}
+			}
+
+			progress.SetValue(0, float64(now.Sub(start))/float64(duration))
+		}
+	}()
+
+	wg.Wait()
+
+	progress.Complete()
+}

--- a/output/block.go
+++ b/output/block.go
@@ -1,0 +1,59 @@
+package output
+
+import (
+	"bytes"
+	"sync"
+)
+
+// Block represents a block of output with one status line, and then zero or
+// more lines of output nested under the status line.
+type Block struct {
+	*Output
+
+	indent    []byte
+	unwrapped *Output
+	writer    *indentedWriter
+}
+
+func newBlock(indent int, o *Output) *Block {
+	w := &indentedWriter{}
+
+	// Block uses Output's implementation, but with a wrapped writer that
+	// indents all output lines. (Note, however, that o's lock mutex is still
+	// used.)
+	return &Block{
+		Output: &Output{
+			w:    w,
+			caps: o.caps,
+			opts: o.opts,
+		},
+		indent:    bytes.Repeat([]byte(" "), indent),
+		unwrapped: o,
+		writer:    w,
+	}
+}
+
+func (b *Block) Close() {
+	b.unwrapped.Lock()
+	defer b.unwrapped.Unlock()
+
+	// This is a little tricky: output from Writer methods includes a trailing
+	// newline, so we need to trim that so we don't output extra blank lines.
+	for _, line := range bytes.Split(bytes.TrimRight(b.writer.buffer.Bytes(), "\n"), []byte("\n")) {
+		_, _ = b.unwrapped.w.Write(b.indent)
+		_, _ = b.unwrapped.w.Write(line)
+		_, _ = b.unwrapped.w.Write([]byte("\n"))
+	}
+}
+
+type indentedWriter struct {
+	buffer bytes.Buffer
+	lock   sync.Mutex
+}
+
+func (w *indentedWriter) Write(p []byte) (int, error) {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	return w.buffer.Write(p)
+}

--- a/output/capabilities.go
+++ b/output/capabilities.go
@@ -1,0 +1,69 @@
+package output
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/mattn/go-isatty"
+	"github.com/nsf/termbox-go"
+)
+
+type capabilities struct {
+	Color  bool
+	Isatty bool
+	Height int
+	Width  int
+}
+
+func detectCapabilities() capabilities {
+	// There's a pretty obvious flaw here in that we only check the terminal
+	// size once. We may want to consider adding a background goroutine that
+	// updates the capabilities struct every second or two.
+	//
+	// Pulling in termbox is probably overkill, but finding a pure Go library
+	// that could just provide terminfo was surprisingly hard. At least termbox
+	// is widely used.
+	w, h := 80, 25
+	if err := termbox.Init(); err == nil {
+		w, h = termbox.Size()
+		termbox.Close()
+	}
+
+	atty := isatty.IsTerminal(os.Stdout.Fd())
+
+	return capabilities{
+		Color:  detectColor(atty),
+		Isatty: atty,
+		Height: h,
+		Width:  w,
+	}
+}
+
+func detectColor(atty bool) bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+
+	if color := os.Getenv("COLOR"); color != "" {
+		enabled, _ := strconv.ParseBool(color)
+		return enabled
+	}
+
+	if !atty {
+		return false
+	}
+
+	return true
+}
+
+func (c *capabilities) formatArgs(args []interface{}) []interface{} {
+	out := make([]interface{}, len(args))
+	for i, arg := range args {
+		if _, ok := arg.(Style); ok && !c.Color {
+			out[i] = ""
+		} else {
+			out[i] = arg
+		}
+	}
+	return out
+}

--- a/output/emoji.go
+++ b/output/emoji.go
@@ -1,0 +1,9 @@
+package output
+
+// Standard emoji for use in output.
+const (
+	EmojiFailure   = "❌"
+	EmojiWarning   = "❗️"
+	EmojiSuccess   = "✅"
+	EmojiLightbulb = "💡"
+)

--- a/output/line.go
+++ b/output/line.go
@@ -1,0 +1,44 @@
+package output
+
+import (
+	"fmt"
+	"io"
+)
+
+// FancyLine is a formatted output line with an optional emoji and style.
+type FancyLine struct {
+	emoji  string
+	style  Style
+	format string
+	args   []interface{}
+}
+
+// Line creates a new FancyLine without a format string.
+func Line(emoji string, style Style, s string) FancyLine {
+	return FancyLine{
+		emoji:  emoji,
+		style:  style,
+		format: "%s",
+		args:   []interface{}{s},
+	}
+}
+
+// Line creates a new FancyLine with a format string. As with Writer, the
+// arguments may include Style instances with the %s specifier.
+func Linef(emoji string, style Style, format string, a ...interface{}) FancyLine {
+	return FancyLine{
+		emoji:  emoji,
+		style:  style,
+		format: format,
+		args:   a,
+	}
+}
+
+func (ol FancyLine) write(w io.Writer, caps capabilities) {
+	if ol.emoji != "" {
+		fmt.Fprint(w, ol.emoji+" ")
+	}
+
+	fmt.Fprintf(w, "%s"+ol.format+"%s", caps.formatArgs(append(append([]interface{}{ol.style}, ol.args...), StyleReset))...)
+	_, _ = w.Write([]byte("\n"))
+}

--- a/output/noop_writer.go
+++ b/output/noop_writer.go
@@ -1,0 +1,10 @@
+package output
+
+type NoopWriter struct{}
+
+func (NoopWriter) Write(s string)                              {}
+func (NoopWriter) Writef(format string, args ...interface{})   {}
+func (NoopWriter) WriteLine(line FancyLine)                    {}
+func (NoopWriter) Verbose(s string)                            {}
+func (NoopWriter) Verbosef(format string, args ...interface{}) {}
+func (NoopWriter) VerboseLine(line FancyLine)                  {}

--- a/output/output.go
+++ b/output/output.go
@@ -1,0 +1,207 @@
+// Package output provides types related to formatted terminal output.
+package output
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/mattn/go-runewidth"
+)
+
+// Writer defines a common set of methods that can be used to output status
+// information.
+//
+// Note that the *f methods can accept Style instances in their arguments with
+// the %s format specifier: if given, the detected colour support will be
+// respected when outputting.
+type Writer interface {
+	// These methods only write the given message if verbose mode is enabled.
+	Verbose(s string)
+	Verbosef(format string, args ...interface{})
+	VerboseLine(line FancyLine)
+
+	// These methods write their messages unconditionally.
+	Write(s string)
+	Writef(format string, args ...interface{})
+	WriteLine(line FancyLine)
+}
+
+type Context interface {
+	Writer
+
+	Close()
+}
+
+// Output encapsulates a standard set of functionality for commands that need
+// to output human-readable data.
+//
+// Output is not appropriate for machine-readable data, such as JSON.
+type Output struct {
+	w    io.Writer
+	caps capabilities
+	opts OutputOpts
+
+	// Unsurprisingly, it would be bad if multiple goroutines wrote at the same
+	// time, so we have a basic mutex to guard against that.
+	lock sync.Mutex
+}
+
+var _ sync.Locker = &Output{}
+
+type OutputOpts struct {
+	// ForceColor ignores all terminal detection and enabled coloured output.
+	ForceColor bool
+	// ForceTTY ignores all terminal detection and enables TTY output.
+	ForceTTY bool
+
+	// ForceHeight ignores all terminal detection and sets the height to this value.
+	ForceHeight int
+	// ForceWidth ignores all terminal detection and sets the width to this value.
+	ForceWidth int
+
+	Verbose bool
+}
+
+// newOutputPlatformQuirks provides a way for conditionally compiled code to
+// hook into NewOutput to perform any required setup.
+var newOutputPlatformQuirks func(o *Output) error
+
+func NewOutput(w io.Writer, opts OutputOpts) *Output {
+	caps := detectCapabilities()
+	if opts.ForceColor {
+		caps.Color = true
+	}
+	if opts.ForceTTY {
+		caps.Isatty = true
+	}
+	if opts.ForceHeight != 0 {
+		caps.Height = opts.ForceHeight
+	}
+	if opts.ForceWidth != 0 {
+		caps.Width = opts.ForceWidth
+	}
+
+	o := &Output{caps: caps, opts: opts, w: w}
+	if newOutputPlatformQuirks != nil {
+		if err := newOutputPlatformQuirks(o); err != nil {
+			o.Verbosef("Error handling platform quirks: %v", err)
+		}
+	}
+
+	return o
+}
+
+func (o *Output) Lock() {
+	o.lock.Lock()
+
+	// Hide the cursor while we update: this reduces the jitteriness of the
+	// whole thing, and some terminals are smart enough to make the update we're
+	// about to render atomic if the cursor is hidden for a short length of
+	// time.
+	o.w.Write([]byte("\033[?25l"))
+}
+
+func (o *Output) Unlock() {
+	// Show the cursor once more.
+	o.w.Write([]byte("\033[?25h"))
+
+	o.lock.Unlock()
+}
+
+func (o *Output) Verbose(s string) {
+	if o.opts.Verbose {
+		o.Write(s)
+	}
+}
+
+func (o *Output) Verbosef(format string, args ...interface{}) {
+	if o.opts.Verbose {
+		o.Writef(format, args...)
+	}
+}
+
+func (o *Output) VerboseLine(line FancyLine) {
+	if o.opts.Verbose {
+		o.WriteLine(line)
+	}
+}
+
+func (o *Output) Write(s string) {
+	o.Lock()
+	defer o.Unlock()
+	fmt.Fprintln(o.w, s)
+}
+
+func (o *Output) Writef(format string, args ...interface{}) {
+	o.Lock()
+	defer o.Unlock()
+	fmt.Fprintf(o.w, format, o.caps.formatArgs(args)...)
+	fmt.Fprint(o.w, "\n")
+}
+
+func (o *Output) WriteLine(line FancyLine) {
+	o.Lock()
+	defer o.Unlock()
+	line.write(o.w, o.caps)
+}
+
+// Block starts a new block context. This should not be invoked if there is an
+// active Pending or Progress context.
+func (o *Output) Block(summary FancyLine) *Block {
+	o.WriteLine(summary)
+	return newBlock(runewidth.StringWidth(summary.emoji)+1, o)
+}
+
+// Pending sets up a new pending context. This should not be invoked if there
+// is an active Block or Progress context. The emoji in the message will be
+// ignored, as Pending will render its own spinner.
+//
+// A Pending instance must be disposed of via the Complete or Destroy methods.
+func (o *Output) Pending(message FancyLine) Pending {
+	return newPending(message, o)
+}
+
+// Progress sets up a new progress bar context. This should not be invoked if
+// there is an active Block or Pending context.
+//
+// A Progress instance must be disposed of via the Complete or Destroy methods.
+func (o *Output) Progress(bars []ProgressBar, opts *ProgressOpts) Progress {
+	return newProgress(bars, o, opts)
+}
+
+// ProgressWithStatusBars sets up a new progress bar context with StatusBar
+// contexts. This should not be invoked if there is an active Block or Pending
+// context.
+//
+// A Progress instance must be disposed of via the Complete or Destroy methods.
+func (o *Output) ProgressWithStatusBars(bars []ProgressBar, statusBars []*StatusBar, opts *ProgressOpts) ProgressWithStatusBars {
+	return newProgressWithStatusBars(bars, statusBars, o, opts)
+}
+
+// The utility functions below do not make checks for whether the terminal is a
+// TTY, and should only be invoked from behind appropriate guards.
+
+func (o *Output) clearCurrentLine() {
+	fmt.Fprint(o.w, "\033[2K")
+}
+
+func (o *Output) moveDown(lines int) {
+	fmt.Fprintf(o.w, "\033[%dB", lines)
+
+	// Move the cursor to the leftmost column.
+	fmt.Fprintf(o.w, "\033[%dD", o.caps.Width+1)
+}
+
+func (o *Output) moveUp(lines int) {
+	fmt.Fprintf(o.w, "\033[%dA", lines)
+
+	// Move the cursor to the leftmost column.
+	fmt.Fprintf(o.w, "\033[%dD", o.caps.Width+1)
+}
+
+// writeStyle is a helper to write a style while respecting the terminal
+// capabilities.
+func (o *Output) writeStyle(style Style) {
+	fmt.Fprintf(o.w, "%s", o.caps.formatArgs([]interface{}{style})...)
+}

--- a/output/output.go
+++ b/output/output.go
@@ -99,12 +99,12 @@ func (o *Output) Lock() {
 	// whole thing, and some terminals are smart enough to make the update we're
 	// about to render atomic if the cursor is hidden for a short length of
 	// time.
-	o.w.Write([]byte("\033[?25l"))
+	fmt.Fprint(o.w, "\033[?25l")
 }
 
 func (o *Output) Unlock() {
 	// Show the cursor once more.
-	o.w.Write([]byte("\033[?25h"))
+	fmt.Fprint(o.w, "\033[?25h")
 
 	o.lock.Unlock()
 }

--- a/output/output_windows.go
+++ b/output/output_windows.go
@@ -1,0 +1,36 @@
+package output
+
+import (
+	"github.com/hashicorp/go-multierror"
+	"golang.org/x/sys/windows"
+)
+
+func init() {
+	newOutputPlatformQuirks = func(o *Output) error {
+		var errs *multierror.Error
+
+		if err := setConsoleMode(windows.Stdout, windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+		if err := setConsoleMode(windows.Stderr, windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+
+		return errs.ErrorOrNil()
+	}
+}
+
+func setConsoleMode(handle windows.Handle, flags uint32) error {
+	// This is shamelessly lifted from gitlab-runner, specifically
+	// https://gitlab.com/gitlab-org/gitlab-runner/blob/f8d87f1e3e3af1cc8aadcea3e40bbb069eee72ef/helpers/cli/init_cli_windows.go
+
+	// First we have to get the current console mode so we can add the desired
+	// flags.
+	var mode uint32
+	if err := windows.GetConsoleMode(handle, &mode); err != nil {
+		return err
+	}
+
+	// Now we can set the console mode.
+	return windows.SetConsoleMode(handle, mode|flags)
+}

--- a/output/pending.go
+++ b/output/pending.go
@@ -1,0 +1,26 @@
+package output
+
+type Pending interface {
+	// Anything sent to the Writer methods will be displayed as a log message
+	// above the pending line.
+	Context
+
+	// Update and Updatef change the message shown after the spinner.
+	Update(s string)
+	Updatef(format string, args ...interface{})
+
+	// Complete stops the spinner and replaces the pending line with the given
+	// message.
+	Complete(message FancyLine)
+
+	// Destroy stops the spinner and removes the pending line.
+	Destroy()
+}
+
+func newPending(message FancyLine, o *Output) Pending {
+	if !o.caps.Isatty {
+		return newPendingSimple(message, o)
+	}
+
+	return newPendingTTY(message, o)
+}

--- a/output/pending_simple.go
+++ b/output/pending_simple.go
@@ -1,0 +1,26 @@
+package output
+
+type pendingSimple struct {
+	*Output
+}
+
+func (p *pendingSimple) Update(s string) {
+	p.Write(s + "...")
+}
+
+func (p *pendingSimple) Updatef(format string, args ...interface{}) {
+	p.Writef(format+"...", args...)
+}
+
+func (p *pendingSimple) Complete(message FancyLine) {
+	p.WriteLine(message)
+}
+
+func (p *pendingSimple) Close()   {}
+func (p *pendingSimple) Destroy() {}
+
+func newPendingSimple(message FancyLine, o *Output) *pendingSimple {
+	message.format += "..."
+	o.WriteLine(message)
+	return &pendingSimple{o}
+}

--- a/output/pending_tty.go
+++ b/output/pending_tty.go
@@ -1,0 +1,160 @@
+package output
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/mattn/go-runewidth"
+)
+
+type pendingTTY struct {
+	o       *Output
+	line    FancyLine
+	spinner *spinner
+}
+
+func (p *pendingTTY) Verbose(s string) {
+	if p.o.opts.Verbose {
+		p.Write(s)
+	}
+}
+
+func (p *pendingTTY) Verbosef(format string, args ...interface{}) {
+	if p.o.opts.Verbose {
+		p.Writef(format, args...)
+	}
+}
+
+func (p *pendingTTY) VerboseLine(line FancyLine) {
+	if p.o.opts.Verbose {
+		p.WriteLine(line)
+	}
+}
+
+func (p *pendingTTY) Write(s string) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.o.moveUp(1)
+	p.o.clearCurrentLine()
+	fmt.Fprintln(p.o.w, s)
+	p.write(p.line)
+}
+
+func (p *pendingTTY) Writef(format string, args ...interface{}) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.o.moveUp(1)
+	p.o.clearCurrentLine()
+	fmt.Fprintf(p.o.w, format, p.o.caps.formatArgs(args)...)
+	fmt.Fprint(p.o.w, "\n")
+	p.write(p.line)
+}
+
+func (p *pendingTTY) WriteLine(line FancyLine) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.o.moveUp(1)
+	p.o.clearCurrentLine()
+	line.write(p.o.w, p.o.caps)
+	p.write(p.line)
+}
+
+func (p *pendingTTY) Update(s string) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.line.format = "%s"
+	p.line.args = []interface{}{s}
+
+	p.o.moveUp(1)
+	p.o.clearCurrentLine()
+	p.write(p.line)
+}
+
+func (p *pendingTTY) Updatef(format string, args ...interface{}) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.line.format = format
+	p.line.args = args
+
+	p.o.moveUp(1)
+	p.o.clearCurrentLine()
+	p.write(p.line)
+}
+
+func (p *pendingTTY) Complete(message FancyLine) {
+	p.spinner.stop()
+
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.o.moveUp(1)
+	p.o.clearCurrentLine()
+	p.write(message)
+}
+
+func (p *pendingTTY) Close() { p.Destroy() }
+
+func (p *pendingTTY) Destroy() {
+	p.spinner.stop()
+
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.o.moveUp(1)
+	p.o.clearCurrentLine()
+}
+
+func newPendingTTY(message FancyLine, o *Output) *pendingTTY {
+	p := &pendingTTY{
+		o:       o,
+		line:    message,
+		spinner: newSpinner(100 * time.Millisecond),
+	}
+	p.updateEmoji(spinnerStrings[0])
+	fmt.Fprintln(p.o.w, "")
+
+	go func() {
+		for s := range p.spinner.C {
+			func() {
+				p.o.Lock()
+				defer p.o.Unlock()
+
+				p.updateEmoji(s)
+
+				p.o.moveUp(1)
+				p.o.clearCurrentLine()
+				p.write(p.line)
+			}()
+		}
+	}()
+
+	return p
+}
+
+func (p *pendingTTY) updateEmoji(emoji string) {
+	// We add an extra space because the Braille characters are single width,
+	// but emoji are generally double width and that's what will most likely be
+	// used in the completion message, if any.
+	p.line.emoji = fmt.Sprintf("%s%s ", p.o.caps.formatArgs([]interface{}{
+		p.line.style,
+		emoji,
+	})...)
+}
+
+func (p *pendingTTY) write(message FancyLine) {
+	var buf bytes.Buffer
+
+	// This appends a newline to buf, so we have to be careful to ensure that
+	// we also add a newline if the line is truncated.
+	message.write(&buf, p.o.caps)
+
+	// FIXME: This doesn't account for escape codes right now, so we may
+	// truncate shorter than we mean to.
+	fmt.Fprint(p.o.w, runewidth.Truncate(buf.String(), p.o.caps.Width, "...\n"))
+}

--- a/output/progress.go
+++ b/output/progress.go
@@ -1,0 +1,60 @@
+package output
+
+type Progress interface {
+	Context
+
+	// Complete stops the set of progress bars and marks them all as completed.
+	Complete()
+
+	// Destroy stops the set of progress bars and clears them from the
+	// terminal.
+	Destroy()
+
+	// SetLabel updates the label for the given bar.
+	SetLabel(i int, label string)
+
+	// SetLabelAndRecalc updates the label for the given bar and recalculates
+	// the maximum width of the labels.
+	SetLabelAndRecalc(i int, label string)
+
+	// SetValue updates the value for the given bar.
+	SetValue(i int, v float64)
+}
+
+type ProgressBar struct {
+	Label string
+	Max   float64
+	Value float64
+
+	labelWidth int
+}
+
+type ProgressOpts struct {
+	PendingStyle Style
+	SuccessEmoji string
+	SuccessStyle Style
+
+	// NoSpinner turns of the automatic updating of the progress bar and
+	// spinner in a background goroutine.
+	// Used for testing only!
+	NoSpinner bool
+}
+
+func (opt *ProgressOpts) WithNoSpinner(noSpinner bool) *ProgressOpts {
+	c := *opt
+	c.NoSpinner = noSpinner
+	return &c
+}
+
+func newProgress(bars []ProgressBar, o *Output, opts *ProgressOpts) Progress {
+	barPtrs := make([]*ProgressBar, len(bars))
+	for i := range bars {
+		barPtrs[i] = &bars[i]
+	}
+
+	if !o.caps.Isatty {
+		return newProgressSimple(barPtrs, o, opts)
+	}
+
+	return newProgressTTY(barPtrs, o, opts)
+}

--- a/output/progress_simple.go
+++ b/output/progress_simple.go
@@ -1,0 +1,91 @@
+package output
+
+import (
+	"math"
+	"time"
+)
+
+type progressSimple struct {
+	*Output
+
+	bars []*ProgressBar
+	done chan chan struct{}
+}
+
+func (p *progressSimple) Complete() {
+	p.stop()
+	writeBars(p.Output, p.bars)
+}
+
+func (p *progressSimple) Close()   { p.Destroy() }
+func (p *progressSimple) Destroy() { p.stop() }
+
+func (p *progressSimple) SetLabel(i int, label string) {
+	p.bars[i].Label = label
+}
+
+func (p *progressSimple) SetLabelAndRecalc(i int, label string) {
+	p.bars[i].Label = label
+}
+
+func (p *progressSimple) SetValue(i int, v float64) {
+	p.bars[i].Value = v
+}
+
+func (p *progressSimple) stop() {
+	c := make(chan struct{})
+	p.done <- c
+	<-c
+}
+
+func newProgressSimple(bars []*ProgressBar, o *Output, opts *ProgressOpts) *progressSimple {
+	p := &progressSimple{
+		Output: o,
+		bars:   bars,
+		done:   make(chan chan struct{}),
+	}
+
+	if opts != nil && opts.NoSpinner {
+		if p.Output.opts.Verbose {
+			writeBars(p.Output, p.bars)
+		}
+		return p
+	}
+
+	go func() {
+		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				if p.Output.opts.Verbose {
+					writeBars(p.Output, p.bars)
+				}
+
+			case c := <-p.done:
+				c <- struct{}{}
+				return
+			}
+		}
+	}()
+
+	return p
+}
+
+func writeBar(w Writer, bar *ProgressBar) {
+	w.Writef("%s: %d%%", bar.Label, int64(math.Round((100.0*bar.Value)/bar.Max)))
+}
+
+func writeBars(o *Output, bars []*ProgressBar) {
+	if len(bars) > 1 {
+		block := o.Block(Line("", StyleReset, "Progress:"))
+		defer block.Close()
+
+		for _, bar := range bars {
+			writeBar(block, bar)
+		}
+	} else if len(bars) == 1 {
+		writeBar(o, bars[0])
+	}
+}

--- a/output/progress_tty.go
+++ b/output/progress_tty.go
@@ -1,0 +1,267 @@
+package output
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/mattn/go-runewidth"
+)
+
+var DefaultProgressTTYOpts = &ProgressOpts{
+	SuccessEmoji: "\u2705",
+	SuccessStyle: StyleSuccess,
+	PendingStyle: StylePending,
+}
+
+type progressTTY struct {
+	bars []*ProgressBar
+
+	o    *Output
+	opts ProgressOpts
+
+	emojiWidth   int
+	labelWidth   int
+	pendingEmoji string
+	spinner      *spinner
+}
+
+func (p *progressTTY) Complete() {
+	p.spinner.stop()
+
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	for _, bar := range p.bars {
+		bar.Value = bar.Max
+	}
+	p.drawInSitu()
+}
+
+func (p *progressTTY) Close() { p.Destroy() }
+
+func (p *progressTTY) Destroy() {
+	p.spinner.stop()
+
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.moveToOrigin()
+	for i := 0; i < len(p.bars); i += 1 {
+		p.o.clearCurrentLine()
+		p.o.moveDown(1)
+	}
+
+	p.moveToOrigin()
+}
+
+func (p *progressTTY) SetLabel(i int, label string) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.bars[i].Label = label
+	p.bars[i].labelWidth = runewidth.StringWidth(label)
+	p.drawInSitu()
+}
+
+func (p *progressTTY) SetLabelAndRecalc(i int, label string) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.bars[i].Label = label
+	p.bars[i].labelWidth = runewidth.StringWidth(label)
+
+	p.determineLabelWidth()
+	p.drawInSitu()
+}
+
+func (p *progressTTY) SetValue(i int, v float64) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.bars[i].Value = v
+	p.drawInSitu()
+}
+
+func (p *progressTTY) Verbose(s string) {
+	if p.o.opts.Verbose {
+		p.Write(s)
+	}
+}
+
+func (p *progressTTY) Verbosef(format string, args ...interface{}) {
+	if p.o.opts.Verbose {
+		p.Writef(format, args...)
+	}
+}
+
+func (p *progressTTY) VerboseLine(line FancyLine) {
+	if p.o.opts.Verbose {
+		p.WriteLine(line)
+	}
+}
+
+func (p *progressTTY) Write(s string) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.moveToOrigin()
+	p.o.clearCurrentLine()
+	fmt.Fprintln(p.o.w, s)
+	p.draw()
+}
+
+func (p *progressTTY) Writef(format string, args ...interface{}) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.moveToOrigin()
+	p.o.clearCurrentLine()
+	fmt.Fprintf(p.o.w, format, p.o.caps.formatArgs(args)...)
+	fmt.Fprint(p.o.w, "\n")
+	p.draw()
+}
+
+func (p *progressTTY) WriteLine(line FancyLine) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.moveToOrigin()
+	p.o.clearCurrentLine()
+	line.write(p.o.w, p.o.caps)
+	p.draw()
+}
+
+func newProgressTTY(bars []*ProgressBar, o *Output, opts *ProgressOpts) *progressTTY {
+	p := &progressTTY{
+		bars:         bars,
+		o:            o,
+		emojiWidth:   3,
+		pendingEmoji: spinnerStrings[0],
+		spinner:      newSpinner(100 * time.Millisecond),
+	}
+
+	if opts != nil {
+		p.opts = *opts
+	} else {
+		p.opts = *DefaultProgressTTYOpts
+	}
+
+	p.determineEmojiWidth()
+	p.determineLabelWidth()
+
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.draw()
+
+	if opts != nil && opts.NoSpinner {
+		return p
+	}
+
+	go func() {
+		for s := range p.spinner.C {
+			func() {
+				p.pendingEmoji = s
+
+				p.o.Lock()
+				defer p.o.Unlock()
+
+				p.moveToOrigin()
+				p.draw()
+			}()
+		}
+	}()
+
+	return p
+}
+
+func (p *progressTTY) determineEmojiWidth() {
+	if w := runewidth.StringWidth(p.opts.SuccessEmoji); w > p.emojiWidth {
+		p.emojiWidth = w + 1
+	}
+}
+
+func (p *progressTTY) determineLabelWidth() {
+	p.labelWidth = 0
+	for _, bar := range p.bars {
+		bar.labelWidth = runewidth.StringWidth(bar.Label)
+		if bar.labelWidth > p.labelWidth {
+			p.labelWidth = bar.labelWidth
+		}
+	}
+
+	if maxWidth := p.o.caps.Width/2 - p.emojiWidth; (p.labelWidth + 2) > maxWidth {
+		p.labelWidth = maxWidth - 2
+	}
+}
+
+func (p *progressTTY) draw() {
+	for _, bar := range p.bars {
+		p.writeBar(bar)
+	}
+}
+
+func (p *progressTTY) drawInSitu() {
+	p.moveToOrigin()
+	p.draw()
+}
+
+func (p *progressTTY) moveToOrigin() {
+	p.o.moveUp(len(p.bars))
+}
+
+func (p *progressTTY) writeBar(bar *ProgressBar) {
+	p.o.clearCurrentLine()
+
+	value := bar.Value
+	if bar.Value >= bar.Max {
+		p.o.writeStyle(p.opts.SuccessStyle)
+		fmt.Fprint(p.o.w, runewidth.FillRight(p.opts.SuccessEmoji, p.emojiWidth))
+		value = bar.Max
+	} else {
+		p.o.writeStyle(p.opts.PendingStyle)
+		fmt.Fprint(p.o.w, runewidth.FillRight(p.pendingEmoji, p.emojiWidth))
+	}
+
+	fmt.Fprint(p.o.w, runewidth.FillRight(runewidth.Truncate(bar.Label, p.labelWidth, "..."), p.labelWidth))
+
+	// The bar width is the width of the terminal, minus the label width, minus
+	// two spaces.
+	barWidth := p.o.caps.Width - p.labelWidth - p.emojiWidth - 2
+
+	// Unicode box drawing gives us eight possible bar widths, so we need to
+	// calculate both the bar width and then the final character, if any.
+	var segments int
+	if bar.Max > 0 {
+		segments = int(math.Round((float64(8*barWidth) * value) / bar.Max))
+	}
+
+	fillWidth := segments / 8
+	remainder := segments % 8
+	if remainder == 0 {
+		if fillWidth > barWidth {
+			fillWidth = barWidth
+		}
+	} else {
+		if fillWidth+1 > barWidth {
+			fillWidth = barWidth - 1
+		}
+	}
+
+	fmt.Fprintf(p.o.w, "  ")
+	fmt.Fprint(p.o.w, strings.Repeat("█", fillWidth))
+	fmt.Fprintln(p.o.w, []string{
+		"",
+		"▏",
+		"▎",
+		"▍",
+		"▌",
+		"▋",
+		"▊",
+		"▉",
+	}[remainder])
+
+	p.o.writeStyle(StyleReset)
+}

--- a/output/progress_with_status_bars.go
+++ b/output/progress_with_status_bars.go
@@ -1,0 +1,23 @@
+package output
+
+type ProgressWithStatusBars interface {
+	Progress
+
+	StatusBarUpdatef(i int, format string, args ...interface{})
+	StatusBarCompletef(i int, format string, args ...interface{})
+	StatusBarFailf(i int, format string, args ...interface{})
+	StatusBarResetf(i int, label, format string, args ...interface{})
+}
+
+func newProgressWithStatusBars(bars []ProgressBar, statusBars []*StatusBar, o *Output, opts *ProgressOpts) ProgressWithStatusBars {
+	barPtrs := make([]*ProgressBar, len(bars))
+	for i := range bars {
+		barPtrs[i] = &bars[i]
+	}
+
+	if !o.caps.Isatty {
+		return newProgressWithStatusBarsSimple(barPtrs, statusBars, o, opts)
+	}
+
+	return newProgressWithStatusBarsTTY(barPtrs, statusBars, o, opts)
+}

--- a/output/progress_with_status_bars_simple.go
+++ b/output/progress_with_status_bars_simple.go
@@ -1,0 +1,106 @@
+package output
+
+import (
+	"time"
+)
+
+type progressWithStatusBarsSimple struct {
+	*progressSimple
+
+	statusBars []*StatusBar
+}
+
+func (p *progressWithStatusBarsSimple) Complete() {
+	p.stop()
+	writeBars(p.Output, p.bars)
+	writeStatusBars(p.Output, p.statusBars)
+}
+
+func (p *progressWithStatusBarsSimple) StatusBarUpdatef(i int, format string, args ...interface{}) {
+	if p.statusBars[i] != nil {
+		p.statusBars[i].Updatef(format, args...)
+	}
+}
+
+func (p *progressWithStatusBarsSimple) StatusBarCompletef(i int, format string, args ...interface{}) {
+	if p.statusBars[i] != nil {
+		wasComplete := p.statusBars[i].completed
+		p.statusBars[i].Completef(format, args...)
+		if !wasComplete {
+			writeStatusBar(p.Output, p.statusBars[i])
+		}
+	}
+}
+
+func (p *progressWithStatusBarsSimple) StatusBarFailf(i int, format string, args ...interface{}) {
+	if p.statusBars[i] != nil {
+		wasCompleted := p.statusBars[i].completed
+		p.statusBars[i].Failf(format, args...)
+		if !wasCompleted {
+			writeStatusBar(p.Output, p.statusBars[i])
+		}
+	}
+}
+
+func (p *progressWithStatusBarsSimple) StatusBarResetf(i int, label, format string, args ...interface{}) {
+	if p.statusBars[i] != nil {
+		p.statusBars[i].Resetf(label, format, args...)
+	}
+}
+
+func newProgressWithStatusBarsSimple(bars []*ProgressBar, statusBars []*StatusBar, o *Output, opts *ProgressOpts) *progressWithStatusBarsSimple {
+	p := &progressWithStatusBarsSimple{
+		progressSimple: &progressSimple{
+			Output: o,
+			bars:   bars,
+			done:   make(chan chan struct{}),
+		},
+		statusBars: statusBars,
+	}
+
+	if opts != nil && opts.NoSpinner {
+		if p.Output.opts.Verbose {
+			writeBars(p.Output, p.bars)
+			writeStatusBars(p.Output, p.statusBars)
+		}
+		return p
+	}
+
+	go func() {
+		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				if p.Output.opts.Verbose {
+					writeBars(p.Output, p.bars)
+					writeStatusBars(p.Output, p.statusBars)
+				}
+
+			case c := <-p.done:
+				c <- struct{}{}
+				return
+			}
+		}
+	}()
+
+	return p
+}
+
+func writeStatusBar(w Writer, bar *StatusBar) {
+	w.Writef("%s: "+bar.format, append([]interface{}{bar.label}, bar.args...)...)
+}
+
+func writeStatusBars(o *Output, bars []*StatusBar) {
+	if len(bars) > 1 {
+		block := o.Block(Line("", StyleReset, "Status:"))
+		defer block.Close()
+
+		for _, bar := range bars {
+			writeStatusBar(block, bar)
+		}
+	} else if len(bars) == 1 {
+		writeStatusBar(o, bars[0])
+	}
+}

--- a/output/progress_with_status_bars_tty.go
+++ b/output/progress_with_status_bars_tty.go
@@ -1,0 +1,304 @@
+package output
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mattn/go-runewidth"
+)
+
+func newProgressWithStatusBarsTTY(bars []*ProgressBar, statusBars []*StatusBar, o *Output, opts *ProgressOpts) *progressWithStatusBarsTTY {
+	p := &progressWithStatusBarsTTY{
+		progressTTY: &progressTTY{
+			bars:         bars,
+			o:            o,
+			emojiWidth:   3,
+			pendingEmoji: spinnerStrings[0],
+			spinner:      newSpinner(100 * time.Millisecond),
+		},
+		statusBars: statusBars,
+	}
+
+	if opts != nil {
+		p.opts = *opts
+	} else {
+		p.opts = *DefaultProgressTTYOpts
+	}
+
+	p.determineEmojiWidth()
+	p.determineLabelWidth()
+	p.determineStatusBarLabelWidth()
+
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.draw()
+
+	if opts != nil && opts.NoSpinner {
+		return p
+	}
+
+	go func() {
+		for s := range p.spinner.C {
+			func() {
+				p.pendingEmoji = s
+
+				p.o.Lock()
+				defer p.o.Unlock()
+
+				p.moveToOrigin()
+				p.draw()
+			}()
+		}
+	}()
+
+	return p
+}
+
+type progressWithStatusBarsTTY struct {
+	*progressTTY
+
+	statusBars           []*StatusBar
+	statusBarLabelWidth  int
+	numPrintedStatusBars int
+}
+
+func (p *progressWithStatusBarsTTY) Close() { p.Destroy() }
+
+func (p *progressWithStatusBarsTTY) Destroy() {
+	p.spinner.stop()
+
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.moveToOrigin()
+
+	for i := 0; i < p.lines(); i += 1 {
+		p.o.clearCurrentLine()
+		p.o.moveDown(1)
+	}
+
+	p.moveToOrigin()
+}
+
+func (p *progressWithStatusBarsTTY) Complete() {
+	p.spinner.stop()
+
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	// +1 because of the line between progress and status bars
+	for i := 0; i < p.numPrintedStatusBars+1; i += 1 {
+		p.o.moveUp(1)
+		p.o.clearCurrentLine()
+	}
+	p.statusBars = p.statusBars[0:0]
+
+	for _, bar := range p.bars {
+		bar.Value = bar.Max
+	}
+
+	p.o.moveUp(len(p.bars))
+	p.draw()
+}
+
+func (p *progressWithStatusBarsTTY) lines() int {
+	return len(p.bars) + p.numPrintedStatusBars + 1
+}
+
+func (p *progressWithStatusBarsTTY) SetLabel(i int, label string) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.bars[i].Label = label
+	p.bars[i].labelWidth = runewidth.StringWidth(label)
+	p.drawInSitu()
+}
+
+func (p *progressWithStatusBarsTTY) SetValue(i int, v float64) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.bars[i].Value = v
+	p.drawInSitu()
+}
+
+func (p *progressWithStatusBarsTTY) StatusBarResetf(i int, label, format string, args ...interface{}) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	if p.statusBars[i] != nil {
+		p.statusBars[i].Resetf(label, format, args...)
+	}
+
+	p.determineStatusBarLabelWidth()
+	p.drawInSitu()
+}
+
+func (p *progressWithStatusBarsTTY) StatusBarUpdatef(i int, format string, args ...interface{}) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	if p.statusBars[i] != nil {
+		p.statusBars[i].Updatef(format, args...)
+	}
+
+	p.drawInSitu()
+}
+
+func (p *progressWithStatusBarsTTY) StatusBarCompletef(i int, format string, args ...interface{}) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	if p.statusBars[i] != nil {
+		p.statusBars[i].Completef(format, args...)
+	}
+
+	p.drawInSitu()
+}
+
+func (p *progressWithStatusBarsTTY) StatusBarFailf(i int, format string, args ...interface{}) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	if p.statusBars[i] != nil {
+		p.statusBars[i].Failf(format, args...)
+	}
+
+	p.drawInSitu()
+}
+
+func (p *progressWithStatusBarsTTY) draw() {
+	for _, bar := range p.bars {
+		p.writeBar(bar)
+	}
+
+	if len(p.statusBars) > 0 {
+		p.o.clearCurrentLine()
+		fmt.Fprint(p.o.w, StylePending, "│", runewidth.FillLeft("\n", p.o.caps.Width-1))
+
+	}
+
+	p.numPrintedStatusBars = 0
+	for i, statusBar := range p.statusBars {
+		if statusBar == nil {
+			continue
+		}
+		if !statusBar.initialized {
+			continue
+		}
+
+		last := i == len(p.statusBars)-1
+		p.writeStatusBar(last, statusBar)
+		p.numPrintedStatusBars += 1
+	}
+}
+
+func (p *progressWithStatusBarsTTY) moveToOrigin() {
+	p.o.moveUp(p.lines())
+}
+
+func (p *progressWithStatusBarsTTY) drawInSitu() {
+	p.moveToOrigin()
+	p.draw()
+}
+
+func (p *progressWithStatusBarsTTY) determineStatusBarLabelWidth() {
+	p.statusBarLabelWidth = 0
+	for _, bar := range p.statusBars {
+		labelWidth := runewidth.StringWidth(bar.label)
+		if labelWidth > p.statusBarLabelWidth {
+			p.statusBarLabelWidth = labelWidth
+		}
+	}
+
+	statusBarPrefixWidth := 4 // statusBars have box char and space
+	if maxWidth := p.o.caps.Width/2 - statusBarPrefixWidth; (p.statusBarLabelWidth + 2) > maxWidth {
+		p.statusBarLabelWidth = maxWidth - 2
+	}
+}
+
+func (p *progressWithStatusBarsTTY) writeStatusBar(last bool, statusBar *StatusBar) {
+	style := StylePending
+	if statusBar.completed {
+		if statusBar.failed {
+			style = StyleWarning
+		} else {
+			style = StyleSuccess
+		}
+	}
+
+	box := "├── "
+	if last {
+		box = "└── "
+	}
+	const boxWidth = 4
+
+	labelFillWidth := p.statusBarLabelWidth + 2
+	label := runewidth.FillRight(runewidth.Truncate(statusBar.label, p.statusBarLabelWidth, "..."), labelFillWidth)
+
+	duration := statusBar.runtime().String()
+	durationLength := runewidth.StringWidth(duration)
+
+	textMaxLength := p.o.caps.Width - boxWidth - labelFillWidth - (durationLength + 2)
+	text := runewidth.Truncate(fmt.Sprintf(statusBar.format, p.o.caps.formatArgs(statusBar.args)...), textMaxLength, "...")
+
+	// The text might contain invisible control characters, so we need to
+	// exclude them when counting length
+	textLength := visibleStringWidth(text)
+
+	durationMaxWidth := textMaxLength - textLength + (durationLength + 2)
+	durationText := runewidth.FillLeft(duration, durationMaxWidth)
+
+	p.o.clearCurrentLine()
+	fmt.Fprint(p.o.w, style, box, label, StyleReset, text, StyleBold, durationText, StyleReset, "\n")
+}
+
+func (p *progressWithStatusBarsTTY) Verbose(s string) {
+	if p.o.opts.Verbose {
+		p.Write(s)
+	}
+}
+
+func (p *progressWithStatusBarsTTY) Verbosef(format string, args ...interface{}) {
+	if p.o.opts.Verbose {
+		p.Writef(format, args...)
+	}
+}
+
+func (p *progressWithStatusBarsTTY) VerboseLine(line FancyLine) {
+	if p.o.opts.Verbose {
+		p.WriteLine(line)
+	}
+}
+
+func (p *progressWithStatusBarsTTY) Write(s string) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.moveToOrigin()
+	p.o.clearCurrentLine()
+	fmt.Fprintln(p.o.w, s)
+	p.draw()
+}
+
+func (p *progressWithStatusBarsTTY) Writef(format string, args ...interface{}) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.moveToOrigin()
+	p.o.clearCurrentLine()
+	fmt.Fprintf(p.o.w, format, p.o.caps.formatArgs(args)...)
+	fmt.Fprint(p.o.w, "\n")
+	p.draw()
+}
+
+func (p *progressWithStatusBarsTTY) WriteLine(line FancyLine) {
+	p.o.Lock()
+	defer p.o.Unlock()
+
+	p.moveToOrigin()
+	p.o.clearCurrentLine()
+	line.write(p.o.w, p.o.caps)
+	p.draw()
+}

--- a/output/spinner.go
+++ b/output/spinner.go
@@ -1,0 +1,47 @@
+package output
+
+import "time"
+
+type spinner struct {
+	C chan string
+
+	done chan chan struct{}
+}
+
+var spinnerStrings = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+func newSpinner(interval time.Duration) *spinner {
+	c := make(chan string)
+	done := make(chan chan struct{})
+	s := &spinner{
+		C:    c,
+		done: done,
+	}
+
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		defer close(s.C)
+
+		i := 0
+		for {
+			select {
+			case <-ticker.C:
+				i = (i + 1) % len(spinnerStrings)
+				s.C <- spinnerStrings[i]
+
+			case c := <-done:
+				c <- struct{}{}
+				return
+			}
+		}
+	}()
+
+	return s
+}
+
+func (s *spinner) stop() {
+	c := make(chan struct{})
+	s.done <- c
+	<-c
+}

--- a/output/status_bar.go
+++ b/output/status_bar.go
@@ -1,0 +1,67 @@
+package output
+
+import "time"
+
+// StatusBar is a sub-element of a progress bar that displays the current status
+// of a process.
+type StatusBar struct {
+	completed bool
+	failed    bool
+
+	label  string
+	format string
+	args   []interface{}
+
+	initialized bool
+	startedAt   time.Time
+	finishedAt  time.Time
+}
+
+// Completef sets the StatusBar to completed and updates its text.
+func (sb *StatusBar) Completef(format string, args ...interface{}) {
+	sb.completed = true
+	sb.format = format
+	sb.args = args
+	sb.finishedAt = time.Now()
+}
+
+// Failf sets the StatusBar to completed and failed and updates its text.
+func (sb *StatusBar) Failf(format string, args ...interface{}) {
+	sb.Completef(format, args...)
+	sb.failed = true
+}
+
+// Resetf sets the status of the StatusBar to incomplete and updates its label and text.
+func (sb *StatusBar) Resetf(label, format string, args ...interface{}) {
+	sb.initialized = true
+	sb.completed = false
+	sb.failed = false
+	sb.label = label
+	sb.format = format
+	sb.args = args
+	sb.startedAt = time.Now()
+}
+
+// Updatef updates the StatusBar's text.
+func (sb *StatusBar) Updatef(format string, args ...interface{}) {
+	sb.initialized = true
+	sb.format = format
+	sb.args = args
+}
+
+func (sb *StatusBar) runtime() time.Duration {
+	if sb.startedAt.IsZero() {
+		return 0
+	}
+	if sb.finishedAt.IsZero() {
+		return time.Since(sb.startedAt).Truncate(time.Second)
+	}
+
+	return sb.finishedAt.Sub(sb.startedAt).Truncate(time.Second)
+}
+
+func NewStatusBarWithLabel(label string) *StatusBar {
+	return &StatusBar{label: label, startedAt: time.Now()}
+}
+
+func NewStatusBar() *StatusBar { return &StatusBar{} }

--- a/output/style.go
+++ b/output/style.go
@@ -1,0 +1,60 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Style interface {
+	fmt.Stringer
+}
+
+func CombineStyles(styles ...Style) Style {
+	sb := strings.Builder{}
+	for _, s := range styles {
+		fmt.Fprint(&sb, s)
+	}
+	return &style{sb.String()}
+}
+
+func Fg256Color(code int) Style { return &style{fmt.Sprintf("\033[38;5;%dm", code)} }
+func Bg256Color(code int) Style { return &style{fmt.Sprintf("\033[48;5;%dm", code)} }
+
+type style struct{ code string }
+
+func (s *style) String() string { return s.code }
+
+var (
+	StyleReset      = &style{"\033[0m"}
+	StyleLogo       = Fg256Color(57)
+	StylePending    = Fg256Color(4)
+	StyleWarning    = Fg256Color(124)
+	StyleSuccess    = Fg256Color(2)
+	StyleSuggestion = Fg256Color(244)
+
+	StyleBold      = &style{"\033[1m"}
+	StyleItalic    = &style{"\033[3m"}
+	StyleUnderline = &style{"\033[4m"}
+
+	// Search-specific colors.
+	StyleSearchQuery         = Fg256Color(68)
+	StyleSearchBorder        = Fg256Color(239)
+	StyleSearchLink          = Fg256Color(237)
+	StyleSearchRepository    = Fg256Color(23)
+	StyleSearchFilename      = Fg256Color(69)
+	StyleSearchMatch         = CombineStyles(Fg256Color(0), Bg256Color(11))
+	StyleSearchLineNumbers   = Fg256Color(69)
+	StyleSearchCommitAuthor  = Fg256Color(2)
+	StyleSearchCommitSubject = Fg256Color(68)
+	StyleSearchCommitDate    = Fg256Color(23)
+
+	// Search alert specific colors.
+	StyleSearchAlertTitle               = Fg256Color(124)
+	StyleSearchAlertDescription         = Fg256Color(124)
+	StyleSearchAlertProposedTitle       = &style{""}
+	StyleSearchAlertProposedQuery       = Fg256Color(69)
+	StyleSearchAlertProposedDescription = &style{""}
+
+	StyleLinesDeleted = Fg256Color(196)
+	StyleLinesAdded   = Fg256Color(2)
+)

--- a/output/visible_string_width.go
+++ b/output/visible_string_width.go
@@ -1,0 +1,17 @@
+package output
+
+import (
+	"regexp"
+
+	"github.com/mattn/go-runewidth"
+)
+
+// This regex is taken from here:
+//   https://github.com/acarl005/stripansi/blob/5a71ef0e047df0427e87a79f27009029921f1f9b/stripansi.go
+const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
+
+var ansiRegex = regexp.MustCompile(ansi)
+
+func visibleStringWidth(str string) int {
+	return runewidth.StringWidth(ansiRegex.ReplaceAllString(str, ""))
+}


### PR DESCRIPTION
This extracts the `output` package from `src-cli` and exposes it in `batch-change-utils` so that it can be used in [`sg`](https://github.com/sourcegraph/sourcegraph/blob/main/dev/sg/README.md).

Okay, correction: it _is_ already being used by `sg`. This just makes it official. Until now `sg` imported this branch here.