### PR TITLE
Return nil when a BoolOrString doesn't match

### DIFF
--- a/overridable/bool_or_string.go
+++ b/overridable/bool_or_string.go
@@ -18,20 +18,12 @@ func FromBoolOrString(v interface{}) BoolOrString {
 
 // Value returns the value for the given repository.
 func (bs *BoolOrString) Value(name string) interface{} {
-	v := bs.rules.Match(name)
-	if v == nil {
-		return false
-	}
-	return v
+	return bs.rules.Match(name)
 }
 
 // ValueWithSuffix returns the value for the given repository and branch name.
 func (bs *BoolOrString) ValueWithSuffix(name, suffix string) interface{} {
-	v := bs.rules.MatchWithSuffix(name, suffix)
-	if v == nil {
-		return false
-	}
-	return v
+	return bs.rules.MatchWithSuffix(name, suffix)
 }
 
 // MarshalJSON encodes the BoolOrString overridable to a json representation.

--- a/overridable/bool_or_string_test.go
+++ b/overridable/bool_or_string_test.go
@@ -40,7 +40,7 @@ func TestBoolOrStringIs(t *testing.T) {
 				rules: rules{{pattern: "bar*", value: true}},
 			},
 			input:      "foo",
-			wantParsed: false,
+			wantParsed: nil,
 		},
 		"single match": {
 			def: BoolOrString{
@@ -105,7 +105,7 @@ func TestBoolOrStringWithSuffix(t *testing.T) {
 			},
 			inputName:   "should-not-matter",
 			inputSuffix: "horse",
-			wantParsed:  false,
+			wantParsed:  nil,
 		},
 		"pattern does not match but suffix does": {
 			def: BoolOrString{
@@ -113,7 +113,7 @@ func TestBoolOrStringWithSuffix(t *testing.T) {
 			},
 			inputName:   "will-not-match",
 			inputSuffix: "the-suffix",
-			wantParsed:  false,
+			wantParsed:  nil,
 		},
 
 		"suffix given but not in rule": {


### PR DESCRIPTION
This was something I missed when I made the earlier `src` changes to support publish from UI: if there's a complex `published` field, then the fallback still goes to `false` if there's no repo/branch match, instead of the correct `nil`. There will be a corresponding src-cli PR momentarily to pull this in and ensure we replicate this behaviour on older Sourcegraph versions.